### PR TITLE
Correct typos and grammar

### DIFF
--- a/src/_manual/apps/config.md
+++ b/src/_manual/apps/config.md
@@ -1,5 +1,5 @@
 ---
-title: okta app config
+title: okta apps config
 nav: config
 layout: manual
 subcommand: true

--- a/src/_manual/apps/create.md
+++ b/src/_manual/apps/create.md
@@ -1,11 +1,11 @@
 ---
-title: okta app create
+title: okta apps create
 nav: create
 layout: manual
 subcommand: true
 ---
 
-Create an new Okta app
+Create a new Okta app
 
 ## Usage
 ```bash

--- a/src/_manual/apps/delete.md
+++ b/src/_manual/apps/delete.md
@@ -1,5 +1,5 @@
 ---
-title: okta app delete
+title: okta apps delete
 nav: delete
 layout: manual
 subcommand: true

--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@ layout: home
       <h1 class="mb-3">Okta CLI (beta) Documentation</h1>
 
       <div>The Okta CLI is the easiest way to get started with Okta!</div>
-      <div>Get stated today by installing on your platform.</div>
+      <div>Get started today by installing on your platform.</div>
     </div>
     <div class="install-mac d-none">
       <pre><code class="marked-code d-flex flex-column flex-md-row flex-items-stretch"><div class="code flex-1 flex-order-2 flex-md-order-1">brew install --cask oktadeveloper/tap/okta</div><div class="marker rounded-md-3 flex-order-1 flex-md-order-2">macOS Install</div></code></pre>
@@ -66,7 +66,7 @@ $</span></code></pre>
 
 <div id="marketing" class="home-marketing">
   <div class="container-lg py-6 px-4 d-flex flex-column flex-items-center">
-    <h2 class="marketing-header mb-6">Improve your Workfow</h2>
+    <h2 class="marketing-header mb-6">Improve your Workflow</h2>
     <div class="d-flex flex-column flex-md-row flex-justify-between">
       <div class="flex-1 px-2 mb-6">
         <h3 class="mb-3">Manage All the Things</h3>


### PR DESCRIPTION
Corrects a few typos and grammar in the site.

- Home page: Get sta[r]ted today by installing on your platform.
- Home page: Improve your Workf[l]ow
- Manual, Okta Apps Subcommands: okta app[s]
- Manual, Okta Apps Create: Create a~n~ new Okta app (This is also an issue in the CLI codebase)